### PR TITLE
Hotfix/cli test fetch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,11 @@ jobs:
           name: Execute mutagene fetch
           command: |
             pipenv run mutagene -v fetch cohorts MSKCC --cohort paac_jhu_2014
-            FETCH_MD5SUM=$(md5sum paac_jhu_2014.tar.gz | awk '{print $1}')
-            [ $FETCH_MD5SUM = 'b7709f55eaeade1b1c6102d134b16c18' ]
+            # Removed due to inconsistent md5 sums across repeated downloads, affecting both this test and pytest
+            #FETCH_MD5SUM=$(md5sum paac_jhu_2014.tar.gz | awk '{print $1}')
+            #[ $FETCH_MD5SUM = 'acbf8c569c2b8f5684ccfb1e036743f0' ]
+            FETCH_SIZE=$(stat -c %s paac_jhu_2014.tar.gz)
+            [ $FETCH_SIZE = '271744' ]
 
       - run:
           name: Execute mutagene motif

--- a/tests/cli/cli_test.py
+++ b/tests/cli/cli_test.py
@@ -10,9 +10,12 @@ def test_fetch():
     file_name = 'paac_jhu_2014.tar.gz'
     os.rename(f'./{file_name}', f'{cli_test_utils.TEST_DIR}/{file_name}')
 
-    file_md5sum = cli_test_utils.md5sum(f'{cli_test_utils.TEST_DIR}/{file_name}')
+    # Removed due to inconsistent md5 sums across repeated downloads, affecting both this test and CircleCI
+    #file_md5sum = cli_test_utils.md5sum(f'{cli_test_utils.TEST_DIR}/{file_name}')
+    #assert file_md5sum == 'acbf8c569c2b8f5684ccfb1e036743f0'
 
-    assert file_md5sum == '597d7dea428424560cb5559cd24838d6'
+    file_size = os.path.getsize(f'{cli_test_utils.TEST_DIR}/{file_name}')
+    assert file_size == 271744
 
 
 def test_profile(artifactory_circleci):


### PR DESCRIPTION
Switch 'mutagene fetch' tests in pytest and CircleCI to use file length instead of md5 checksum due to inconsistent checksum values.  Tests passed successfully during my testing.