### PR TITLE
Code review fixes and refactoring for the webapp

### DIFF
--- a/mutagene/__main__.py
+++ b/mutagene/__main__.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 genome_error_message = (
     "requires genome name argument -g hg19, hg38, mm10, "
-    "see http://hgdownload.cse.ucsc.edu/downloads.html for more. "
+    "see http://hgdownload.soe.ucsc.edu/downloads.html for more. "
     "Use mutagene fetch to download genome assemblies"
 )
 

--- a/mutagene/cli/fetch_menu.py
+++ b/mutagene/cli/fetch_menu.py
@@ -7,7 +7,7 @@ from mutagene.io.fetch import fetch_cohorts, fetch_examples, fetch_genome, fetch
 logger = logging.getLogger(__name__)
 genome_error_message = (
     "requires genome name argument -g hg19, hg38, mm10, "
-    "see http://hgdownload.cse.ucsc.edu/downloads.html for more. "
+    "see http://hgdownload.soe.ucsc.edu/downloads.html for more. "
     "Use mutagene fetch to download genome assemblies"
 )
 

--- a/mutagene/cli/motif_menu.py
+++ b/mutagene/cli/motif_menu.py
@@ -7,7 +7,7 @@ from mutagene.io.motifs import get_known_motifs, write_motif_matches
 from mutagene.motifs import identify_motifs
 
 logger = logging.getLogger(__name__)
-genome_error_message = """requires genome name argument -g hg19, hg38, mm10, see http://hgdownload.cse.ucsc.edu/downloads.html for more
+genome_error_message = """requires genome name argument -g hg19, hg38, mm10, see http://hgdownload.soe.ucsc.edu/downloads.html for more
                         Use mutagene fetch to download genome assemblies"""
 
 

--- a/mutagene/cli/profile_menu.py
+++ b/mutagene/cli/profile_menu.py
@@ -5,7 +5,7 @@ import sys
 from mutagene.profiles.profile import calc_profile
 
 logger = logging.getLogger(__name__)
-genome_error_message = """requires genome name argument -g hg19, hg38, mm10, see http://hgdownload.cse.ucsc.edu/downloads.html for more
+genome_error_message = """requires genome name argument -g hg19, hg38, mm10, see http://hgdownload.soe.ucsc.edu/downloads.html for more
                           Use mutagene fetch to download genome assemblies"""
 
 

--- a/mutagene/cli/rank_menu.py
+++ b/mutagene/cli/rank_menu.py
@@ -15,7 +15,7 @@ from mutagene.mutability.mutability import THRESHOLD_DRIVER, THRESHOLD_PASSENGER
 from mutagene.profiles.profile import get_pooled_multisample_mutational_profile
 
 logger = logging.getLogger(__name__)
-genome_error_message = """requires genome name argument -g hg19, hg38, mm10, see http://hgdownload.cse.ucsc.edu/downloads.html for more
+genome_error_message = """requires genome name argument -g hg19, hg38, mm10, see http://hgdownload.soe.ucsc.edu/downloads.html for more
                           Use mutagene fetch to download genome assemblies"""
 
 

--- a/mutagene/cli/signature_menu.py
+++ b/mutagene/cli/signature_menu.py
@@ -15,7 +15,7 @@ from mutagene.signatures.identify import IDENTIFY_MIN_FUNCTIONS, decompose_mutat
 
 logger = logging.getLogger(__name__)
 
-genome_error_message = """requires genome name argument -g hg19, hg38, mm10, see http://hgdownload.cse.ucsc.edu/downloads.html for more
+genome_error_message = """requires genome name argument -g hg19, hg38, mm10, see http://hgdownload.soe.ucsc.edu/downloads.html for more
                           Use mutagene fetch to download genome assemblies"""
 
 

--- a/mutagene/io/fetch.py
+++ b/mutagene/io/fetch.py
@@ -67,13 +67,13 @@ def download_from_url(url, dst):
 
 
 def fetch_genome(name):
-    # ftp://hgdownload.cse.ucsc.edu/goldenPath/hg19/bigZips/hg19.2bit
-    # http://hgdownload.cse.ucsc.edu/goldenPath/hg19/bigZips/hg19.2bit
+    # ftp://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.2bit
+    # http://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.2bit
     assembly = name.rsplit(".", 1)[0] if ".2bit" in name else name
     assembly = assembly.lower()
     mode = "http"
 
-    url = f"{mode}://hgdownload.cse.ucsc.edu/goldenPath/{assembly}/bigZips/{assembly}.2bit"
+    url = f"{mode}://hgdownload.soe.ucsc.edu/goldenPath/{assembly}/bigZips/{assembly}.2bit"
     dst = f"{assembly}.2bit"
     download_from_url(url, dst)
 

--- a/mutagene/io/protein_mutations_MAF.py
+++ b/mutagene/io/protein_mutations_MAF.py
@@ -175,7 +175,7 @@ def read_protein_mutations_MAF(infile, genome, motifs=False):
             else:
                 if genome.upper() == "MAF":
                     logger.warning(
-                        "ref_context not found in MAF file. Provide genome name argument -g hg19, hg38, mm10, see http://hgdownload.cse.ucsc.edu/downloads.html for more"
+                        "ref_context not found in MAF file. Provide genome name argument -g hg19, hg38, mm10, see http://hgdownload.soe.ucsc.edu/downloads.html for more"
                     )
                     break
 

--- a/mutagene/webapp/analysis.py
+++ b/mutagene/webapp/analysis.py
@@ -3,6 +3,7 @@
 import gzip
 import json
 import logging
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,14 @@ from mutagene.profiles.profile import calc_profile
 from .genome_manager import GenomeManager
 
 logger = logging.getLogger(__name__)
+
+# A few hundred MB of mutation text is far beyond any realistic MAF; the cap
+# stops a small tarball from expanding into a disk-filling extract.
+MAX_EXTRACTED_BYTES = 2 * 1024 * 1024 * 1024
+
+# Per-sample decomposition is linear but clustering builds an N x N distance
+# matrix, so a file with many unique sample IDs is a memory-exhaustion vector.
+MAX_CLUSTERING_SAMPLES = 1000
 
 
 def extract_input_file(file_path: Path, output_dir: Path) -> Path:
@@ -32,16 +41,51 @@ def extract_input_file(file_path: Path, output_dir: Path) -> Path:
                 raise ValueError("No mutation file found in tar.gz archive")
 
             maf_member = maf_candidates[0]
+            if maf_member.size > MAX_EXTRACTED_BYTES:
+                raise ValueError(
+                    f"Archived mutation file is too large "
+                    f"({maf_member.size} bytes, limit {MAX_EXTRACTED_BYTES})"
+                )
             logger.info(f"Extracting {maf_member.name} from tarball")
 
             extract_dir = output_dir / "extracted"
-            extract_dir.mkdir(exist_ok=True)
-            extracted_path = (extract_dir / Path(maf_member.name).name).resolve()
-            if not str(extracted_path).startswith(str(extract_dir.resolve())):
+            extract_dir.mkdir(parents=True, exist_ok=True)
+
+            # Never trust the member name: it may contain path separators, "..",
+            # or be an absolute path. Stream the member out under a basename we
+            # control instead of letting tarfile choose the destination.
+            safe_name = Path(maf_member.name).name
+            if not safe_name or safe_name in (".", ".."):
+                raise ValueError(
+                    f"Refusing to extract tar member with unsafe name: {maf_member.name!r}"
+                )
+
+            extracted_path = extract_dir / safe_name
+            resolved = extracted_path.resolve()
+            if not resolved.is_relative_to(extract_dir.resolve()):
                 raise ValueError(
                     f"Tar member {maf_member.name} would extract outside target directory"
                 )
-            tar.extract(maf_member, path=extract_dir)
+
+            source = tar.extractfile(maf_member)
+            if source is None:
+                raise ValueError(f"Tar member {maf_member.name} is not a regular file")
+
+            # Enforce the cap while copying rather than trusting the header size,
+            # which an attacker controls independently of the actual stream.
+            written = 0
+            try:
+                with source, open(extracted_path, "wb") as dest:
+                    while chunk := source.read(1024 * 1024):
+                        written += len(chunk)
+                        if written > MAX_EXTRACTED_BYTES:
+                            raise ValueError(
+                                f"Archived mutation file exceeds {MAX_EXTRACTED_BYTES} bytes"
+                            )
+                        dest.write(chunk)
+            except Exception:
+                extracted_path.unlink(missing_ok=True)
+                raise
             return extracted_path
 
     return file_path
@@ -52,6 +96,29 @@ def open_input_file(file_path: Path, mode: str = "rt"):
     if str(file_path).endswith(".gz"):
         return gzip.open(file_path, mode, encoding="utf-8")
     return open(file_path, mode, encoding="utf-8")
+
+
+def profile_channel_order() -> list[str]:
+    """Return the canonical 96 mutation channel labels in signature-matrix row order.
+
+    The signature matrices returned by ``read_signatures`` and the profiles written
+    by ``calc_profile`` both follow ``get_profile_attributes_dict()`` order
+    (5' base, 3' base, then mutation). Sorting the labels alphabetically yields a
+    *different* permutation, so the two must never be zipped together by sorted key.
+    """
+    from mutagene.io.profile import get_profile_attributes_dict
+
+    return [
+        f"{a['context'][0]}[{a['mutation'][0]}>{a['mutation'][1]}]{a['context'][1]}"
+        for a in get_profile_attributes_dict()
+    ]
+
+
+def profile_dict_to_array(profile_data: dict[str, int]):
+    """Convert a ``{'A[C>T]G': count}`` dict into a 96-element array in signature order."""
+    import numpy as np
+
+    return np.array([profile_data.get(k, 0) for k in profile_channel_order()], dtype=float)
 
 
 def run_cohort_analysis(
@@ -121,11 +188,20 @@ def run_cohort_analysis(
         import logging as _logging
 
         class MismatchCounter(_logging.Handler):
+            """Count REF-mismatch warnings emitted by *this* thread only.
+
+            The handler is attached to a module-level logger shared by every
+            concurrent analysis, so records from other analyses must be ignored.
+            """
+
             def __init__(self):
                 super().__init__()
                 self.mismatch_count = 0
+                self._thread_id = threading.get_ident()
 
             def emit(self, record):
+                if record.thread != self._thread_id:
+                    return
                 if "REF allele does not match" in record.getMessage():
                     self.mismatch_count += 1
 
@@ -197,9 +273,9 @@ def run_cohort_analysis(
             logger.info(f"Loaded {len(signature_names)} signatures from {signatures_set}")
             logger.info(f"Signature matrix shape: {W.shape}")
 
-            # Convert profile_data dict to numpy array in correct order
-            profile_keys = sorted(profile_data.keys())
-            profile_array = np.array([profile_data[k] for k in profile_keys], dtype=float)
+            # Convert profile_data dict to numpy array in signature-matrix row order.
+            # NB: this must match W's row order, not alphabetical key order.
+            profile_array = profile_dict_to_array(profile_data)
 
             logger.info(f"Profile array shape: {profile_array.shape}, sum: {profile_array.sum()}")
 
@@ -368,7 +444,13 @@ def run_cohort_analysis(
                     logger.info(f"Exposure matrix shape: {exposure_matrix.shape}")
 
                     # Perform hierarchical clustering
-                    if len(sample_ids) >= 2:
+                    if len(sample_ids) > MAX_CLUSTERING_SAMPLES:
+                        logger.warning(
+                            f"Skipping clustering: {len(sample_ids)} samples exceeds the "
+                            f"limit of {MAX_CLUSTERING_SAMPLES} (pairwise distance matrix "
+                            f"grows quadratically)"
+                        )
+                    elif len(sample_ids) >= 2:
                         # Calculate cosine distance
                         distances = pdist(exposure_matrix, metric="cosine")
                         linkage_matrix = linkage(distances, method="average")
@@ -464,10 +546,8 @@ def run_cohort_analysis(
                 logger.info(f"Loaded {protein_stats.get('loaded', 0)} protein mutations")
 
                 if protein_mutations:
-                    # Get profile for mutability calculation
-                    profile_array_for_rank = np.array(
-                        [profile_data[k] for k in sorted(profile_data.keys())], dtype=float
-                    )
+                    # Get profile for mutability calculation (signature-matrix row order)
+                    profile_array_for_rank = profile_dict_to_array(profile_data)
 
                     # Try to load precalculated cohort data
                     cohorts_file = Path.home() / ".mutagene" / "cohorts.tar.gz"

--- a/mutagene/webapp/database/manager.py
+++ b/mutagene/webapp/database/manager.py
@@ -35,6 +35,9 @@ class DatabaseManager:
         """Context manager for database connections."""
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
+        # Required for the ON DELETE CASCADE clauses in the schema to fire;
+        # SQLite disables foreign key enforcement per-connection by default.
+        conn.execute("PRAGMA foreign_keys = ON")
         try:
             yield conn
         finally:
@@ -60,6 +63,16 @@ class DatabaseManager:
         """Update analysis status."""
         with self.get_connection() as conn:
             Analysis.update_status(conn, analysis_id, status, error_message)
+
+    def reset_stale_running(self):
+        """Mark analyses orphaned by a server restart as failed; returns the count."""
+        with self.get_connection() as conn:
+            return Analysis.reset_stale_running(conn)
+
+    def try_claim_analysis(self, analysis_id):
+        """Atomically mark an analysis as running; True if this caller claimed it."""
+        with self.get_connection() as conn:
+            return Analysis.try_claim(conn, analysis_id)
 
     def update_analysis_counts(self, analysis_id, samples, mutations):
         """Update sample and mutation counts."""

--- a/mutagene/webapp/database/models.py
+++ b/mutagene/webapp/database/models.py
@@ -142,6 +142,44 @@ class Analysis:
         conn.commit()
 
     @staticmethod
+    def try_claim(conn, analysis_id):
+        """Atomically move an analysis to 'running'.
+
+        Returns True if this caller won the claim, False if the analysis was
+        already running or does not exist. Doing the check and the update in one
+        statement prevents two concurrent requests from both starting the same
+        analysis.
+        """
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            UPDATE analyses
+            SET status = 'running', error_message = NULL
+            WHERE id = ? AND status != 'running'
+        """,
+            (analysis_id,),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+    @staticmethod
+    def reset_stale_running(conn):
+        """Fail analyses left 'running' by a process that exited.
+
+        Analysis workers are in-process daemon threads, so a restart orphans
+        anything still running. Returns the number of rows reset.
+        """
+        cursor = conn.cursor()
+        cursor.execute("""
+            UPDATE analyses
+            SET status = 'error',
+                error_message = 'Analysis was interrupted by a server restart'
+            WHERE status = 'running'
+        """)
+        conn.commit()
+        return cursor.rowcount
+
+    @staticmethod
     def update_counts(conn, analysis_id, samples, mutations):
         """Update sample and mutation counts."""
         cursor = conn.cursor()

--- a/mutagene/webapp/genome_manager.py
+++ b/mutagene/webapp/genome_manager.py
@@ -1,6 +1,7 @@
 """Genome reference management for webapp."""
 
 import logging
+import threading
 from pathlib import Path
 
 from mutagene.io.fetch import download_from_url
@@ -32,6 +33,15 @@ class GenomeManager:
         self.genomes_dir = Path(genomes_dir)
         self.genomes_dir.mkdir(parents=True, exist_ok=True)
 
+        # Serializes downloads per assembly: two concurrent requests for the
+        # same genome would otherwise write the same partial file.
+        self._download_locks: dict[str, threading.Lock] = {}
+        self._locks_guard = threading.Lock()
+
+    def _lock_for(self, genome: str) -> threading.Lock:
+        with self._locks_guard:
+            return self._download_locks.setdefault(genome, threading.Lock())
+
     def get_genome_path(self, genome: str) -> Path:
         """Get the path to a genome file.
 
@@ -40,7 +50,16 @@ class GenomeManager:
 
         Returns:
             Path to the .2bit file
+
+        Raises:
+            ValueError: If *genome* is not a supported assembly name. Rejecting
+                unknown names here keeps request-supplied values from being
+                interpolated into a filesystem path.
         """
+        if genome not in self.SUPPORTED_GENOMES:
+            raise ValueError(
+                f"Unsupported genome: {genome!r}. Supported: {', '.join(self.SUPPORTED_GENOMES)}"
+            )
         return self.genomes_dir / f"{genome}.2bit"
 
     def is_downloaded(self, genome: str) -> bool:
@@ -50,9 +69,13 @@ class GenomeManager:
             genome: Genome assembly name
 
         Returns:
-            True if genome file exists
+            True if genome file exists. Unknown assembly names return False
+            rather than raising, so callers can probe freely.
         """
-        return self.get_genome_path(genome).exists()
+        try:
+            return self.get_genome_path(genome).exists()
+        except ValueError:
+            return False
 
     def get_available_genomes(self) -> list[str]:
         """Get list of available (downloaded) genomes.
@@ -84,19 +107,31 @@ class GenomeManager:
             logger.error(f"Unsupported genome: {genome}")
             return False
 
+        with self._lock_for(genome):
+            return self._download_locked(genome)
+
+    def _download_locked(self, genome: str) -> bool:
+        # Another thread may have finished this download while we waited.
+        if self.is_downloaded(genome):
+            return True
+
         url = self.GENOME_URLS[genome]
-        dst = str(self.get_genome_path(genome))
+        final_path = self.get_genome_path(genome)
+        # Download to a sibling temp file and rename only on success, so an
+        # interrupted download never leaves a truncated file that
+        # is_downloaded() would report as a usable genome.
+        partial_path = final_path.with_name(final_path.name + ".part")
 
         try:
             logger.info(f"Downloading {genome} from {url}")
-            download_from_url(url, dst)
-            logger.info(f"Successfully downloaded {genome} to {dst}")
+            download_from_url(url, str(partial_path))
+            partial_path.replace(final_path)
+            logger.info(f"Successfully downloaded {genome} to {final_path}")
             return True
         except Exception as e:
             logger.error(f"Failed to download {genome}: {e}")
             # Clean up partial download
-            if Path(dst).exists():
-                Path(dst).unlink()
+            partial_path.unlink(missing_ok=True)
             return False
 
     def check_and_download_required_genomes(

--- a/mutagene/webapp/genome_manager.py
+++ b/mutagene/webapp/genome_manager.py
@@ -14,10 +14,10 @@ class GenomeManager:
 
     SUPPORTED_GENOMES = ["hg19", "hg38", "mm10", "mm9"]
     GENOME_URLS = {
-        "hg19": "https://hgdownload.cse.ucsc.edu/goldenPath/hg19/bigZips/hg19.2bit",
-        "hg38": "https://hgdownload.cse.ucsc.edu/goldenPath/hg38/bigZips/hg38.2bit",
-        "mm10": "https://hgdownload.cse.ucsc.edu/goldenPath/mm10/bigZips/mm10.2bit",
-        "mm9": "https://hgdownload.cse.ucsc.edu/goldenPath/mm9/bigZips/mm9.2bit",
+        "hg19": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.2bit",
+        "hg38": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.2bit",
+        "mm10": "https://hgdownload.soe.ucsc.edu/goldenPath/mm10/bigZips/mm10.2bit",
+        "mm9": "https://hgdownload.soe.ucsc.edu/goldenPath/mm9/bigZips/mm9.2bit",
     }
 
     def __init__(self, genomes_dir: Path | None = None):

--- a/mutagene/webapp/server.py
+++ b/mutagene/webapp/server.py
@@ -5,6 +5,7 @@ import os
 import sys
 import threading
 import webbrowser
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from flask import Flask, jsonify, render_template, request, send_file
@@ -15,6 +16,54 @@ from .database import DatabaseManager
 from .genome_manager import GenomeManager
 
 logger = logging.getLogger(__name__)
+
+# Snapshot the genome list at import so request validation is independent of the
+# GenomeManager instance held in app config (which tests replace with a mock).
+SUPPORTED_GENOMES = frozenset(GenomeManager.SUPPORTED_GENOMES)
+
+# Signature sets accepted by mutagene.io.profile.read_signatures
+SUPPORTED_SIGNATURE_SETS = frozenset({"MGA", "MGB", "COSMICv2", "COSMICv3", "KUCAB"})
+
+# Mutation file formats the analysis pipeline can read, plus the archive/compression
+# wrappers extract_input_file() understands.
+ALLOWED_EXTENSIONS = frozenset({".maf", ".vcf", ".txt", ".tsv", ".gz", ".tgz"})
+
+MAX_NAME_LENGTH = 200
+
+
+def _has_allowed_extension(filename: str) -> bool:
+    """True if *filename* ends in an accepted mutation-file extension."""
+    return Path(filename).suffix.lower() in ALLOWED_EXTENSIONS
+
+
+def _form_flag(field: str) -> bool:
+    """Read a checkbox-style form field.
+
+    An unchecked HTML checkbox is omitted from the submission entirely, and a
+    checked one without an explicit value attribute submits the string "on" —
+    so comparing against "true" with a "true" default inverts every option.
+    """
+    value = request.form.get(field)
+    if value is None:
+        return False
+    return value.strip().lower() in ("true", "on", "1", "yes")
+
+
+def _managed_dirs(app) -> list[Path]:
+    """Directories this app is allowed to read from and delete within."""
+    return [Path(app.config["UPLOAD_FOLDER"]), Path(app.config["RESULTS_FOLDER"])]
+
+
+def _is_within(path: Path, directory: Path) -> bool:
+    """True if *path* resolves to a location inside *directory*.
+
+    Uses path-component comparison rather than string prefixing, which would
+    treat "/data/uploads-evil" as living under "/data/uploads".
+    """
+    try:
+        return path.resolve().is_relative_to(directory.resolve())
+    except (OSError, ValueError):
+        return False
 
 
 def create_app(config=None):
@@ -45,51 +94,129 @@ def create_app(config=None):
     app.config["SECRET_KEY"] = secret
     app.config["MAX_CONTENT_LENGTH"] = 500 * 1024 * 1024  # 500 MB max upload
     app.config["UPLOAD_FOLDER"] = Path.home() / ".mutagene" / "uploads"
-    app.config["UPLOAD_FOLDER"].mkdir(parents=True, exist_ok=True)
+    app.config["RESULTS_FOLDER"] = Path.home() / ".mutagene" / "results"
+    # Origins allowed to make state-changing requests. start_server() extends this
+    # with the actual bind host/port; the defaults cover the common case.
+    app.config["ALLOWED_ORIGINS"] = [
+        "http://localhost:5000",
+        "http://127.0.0.1:5000",
+    ]
+    # Hostnames this server will answer to. None disables the check, which is
+    # what start_server() does for a deliberate non-loopback bind where the
+    # hostname clients use cannot be known ahead of time.
+    app.config["ALLOWED_HOSTS"] = ["localhost", "127.0.0.1", "::1"]
+    app.config["AUTO_DOWNLOAD_GENOMES"] = True
+    app.config["MAX_CONCURRENT_ANALYSES"] = 2
 
+    # Apply caller overrides before creating directories, so a test or embedder
+    # pointing UPLOAD_FOLDER elsewhere does not also create the default location.
     if config:
         app.config.update(config)
 
+    app.config["UPLOAD_FOLDER"] = Path(app.config["UPLOAD_FOLDER"])
+    app.config["RESULTS_FOLDER"] = Path(app.config["RESULTS_FOLDER"])
+    app.config["UPLOAD_FOLDER"].mkdir(parents=True, exist_ok=True)
+    app.config["RESULTS_FOLDER"].mkdir(parents=True, exist_ok=True)
+
     # Initialize SocketIO for real-time updates
-    socketio = SocketIO(
-        app, cors_allowed_origins=["http://localhost:5000", "http://127.0.0.1:5000"]
-    )
+    socketio = SocketIO(app, cors_allowed_origins=list(app.config["ALLOWED_ORIGINS"]))
 
     # Initialize database
     db = DatabaseManager()
 
+    # Analyses left mid-flight by a previous process can never finish; without
+    # this they stay 'running' forever and can never be restarted or deleted.
+    reclaimed = db.reset_stale_running()
+    if reclaimed:
+        logger.warning(f"Marked {reclaimed} interrupted analysis(es) as failed")
+
+    app.config["ANALYSIS_EXECUTOR"] = ThreadPoolExecutor(
+        max_workers=app.config["MAX_CONCURRENT_ANALYSES"],
+        thread_name_prefix="mutagene-analysis",
+    )
+
     # Initialize genome manager and check for required genomes
     genome_manager = GenomeManager()
-    logger.info("Checking for required genome files...")
-
-    # First check what's available
-    available = genome_manager.get_available_genomes()
-    if "hg19" in available and "hg38" in available:
-        logger.info(f"All required genomes available: {', '.join(available)}")
-    else:
-        # Auto-download missing genomes
-        logger.info("Downloading required genome files (this may take a few minutes)...")
-        genome_status = genome_manager.check_and_download_required_genomes(
-            required=["hg19", "hg38"], auto_download=True
-        )
-
-        if genome_status["downloaded"]:
-            logger.info(f"Downloaded: {', '.join(genome_status['downloaded'])}")
-
-        if genome_status["missing"]:
-            logger.error(f"Failed to download genomes: {', '.join(genome_status['missing'])}")
-            logger.error("Server may not function properly without genome files")
-        else:
-            logger.info("All required genomes are now available")
-
-    # Store genome manager in app config for access in routes
     app.config["GENOME_MANAGER"] = genome_manager
 
+    _ensure_genomes(genome_manager, auto_download=app.config["AUTO_DOWNLOAD_GENOMES"])
+
     # Register routes
+    register_request_guards(app)
     register_routes(app, db, socketio)
     register_socketio_handlers(socketio, db)
 
     return app, socketio
+
+
+def _ensure_genomes(genome_manager, auto_download=True, required=("hg19", "hg38")):
+    """Check for required genomes, downloading missing ones in the background.
+
+    The reference genomes are several GB each. Downloading them inline would keep
+    the server from accepting connections for many minutes with no UI feedback,
+    so missing genomes are fetched on a daemon thread while the app starts.
+    """
+    logger.info("Checking for required genome files...")
+    available = genome_manager.get_available_genomes()
+    missing = [g for g in required if g not in available]
+
+    if not missing:
+        logger.info(f"All required genomes available: {', '.join(available)}")
+        return
+
+    if not auto_download:
+        logger.warning(f"Missing genome files: {', '.join(missing)}")
+        logger.warning("Download them with: mutagene fetch genome <name>")
+        return
+
+    def download_missing():
+        logger.info(f"Downloading genome files in background: {', '.join(missing)}")
+        status = genome_manager.check_and_download_required_genomes(
+            required=list(missing), auto_download=True
+        )
+        if status["downloaded"]:
+            logger.info(f"Downloaded: {', '.join(status['downloaded'])}")
+        still_missing = [g for g in status["missing"] if g not in status["downloaded"]]
+        if still_missing:
+            logger.error(f"Failed to download genomes: {', '.join(still_missing)}")
+            logger.error("Analyses requiring these assemblies will fail until they are present")
+
+    threading.Thread(target=download_missing, daemon=True).start()
+
+
+def register_request_guards(app):
+    """Reject cross-origin and rebound-DNS requests to this local-only server.
+
+    The app has no authentication and binds to localhost, so any page in the
+    user's browser could otherwise drive it: a plain HTML form can POST
+    multipart data to /api/upload cross-site, and a hostname resolving to
+    127.0.0.1 could reach every endpoint. Checking Origin and Host closes both
+    without adding a token-based CSRF dependency.
+    """
+
+    @app.before_request
+    def guard_request():
+        allowed = set(app.config.get("ALLOWED_ORIGINS", []))
+        allowed_hosts = app.config.get("ALLOWED_HOSTS")
+
+        # DNS-rebinding guard: only answer to hostnames we expect. Disabled
+        # (ALLOWED_HOSTS = None) for a deliberate non-loopback bind.
+        if allowed_hosts is not None:
+            host = (request.host or "").rsplit(":", 1)[0].strip("[]")
+            if host and host not in allowed_hosts:
+                return jsonify({"error": "Invalid Host header"}), 400
+
+        # CSRF guard: browsers always send Origin on cross-site state changes.
+        if request.method not in ("GET", "HEAD", "OPTIONS"):
+            origin = request.headers.get("Origin")
+            if origin is not None and origin not in allowed:
+                return jsonify({"error": "Cross-origin request blocked"}), 403
+        return None
+
+    @app.errorhandler(413)
+    def handle_too_large(_error):
+        limit_mb = app.config["MAX_CONTENT_LENGTH"] // (1024 * 1024)
+        return jsonify({"error": f"File too large (limit {limit_mb} MB)"}), 413
 
 
 def register_routes(app, db, socketio):
@@ -114,18 +241,40 @@ def register_routes(app, db, socketio):
             return jsonify({"error": "No file provided"}), 400
 
         file = request.files["file"]
-        if file.filename == "":
+        if not file.filename:
             return jsonify({"error": "Empty filename"}), 400
 
-        # Get parameters
-        name = request.form.get("name", file.filename)
+        # Validate parameters against known-good values before they reach the
+        # filesystem (genome becomes part of a path) or the analysis pipeline.
         genome = request.form.get("genome", "hg19")
+        if genome not in SUPPORTED_GENOMES:
+            return jsonify({"error": f"Unsupported genome: {genome}"}), 400
+
         signatures = request.form.get("signatures", "COSMICv3")
+        if signatures not in SUPPORTED_SIGNATURE_SETS:
+            return jsonify({"error": f"Unsupported signature set: {signatures}"}), 400
+
+        name = (request.form.get("name") or file.filename).strip()[:MAX_NAME_LENGTH]
+        if not name:
+            return jsonify({"error": "Empty analysis name"}), 400
+
+        safe_name = secure_filename(file.filename)
+        if not safe_name:
+            return jsonify({"error": "Invalid filename"}), 400
+        if not _has_allowed_extension(safe_name):
+            return (
+                jsonify(
+                    {
+                        "error": f"Unsupported file type. Allowed: {', '.join(sorted(ALLOWED_EXTENSIONS))}"
+                    }
+                ),
+                400,
+            )
 
         # Save uploaded file with unique prefix to avoid collisions
         import uuid
 
-        filename = f"{uuid.uuid4().hex[:8]}_{secure_filename(file.filename)}"
+        filename = f"{uuid.uuid4().hex[:8]}_{safe_name}"
         upload_path = app.config["UPLOAD_FOLDER"] / filename
         file.save(str(upload_path))
 
@@ -135,10 +284,10 @@ def register_routes(app, db, socketio):
             genome=genome,
             signatures=signatures,
             config={
-                "classify": request.form.get("classify", "true") == "true",
-                "cluster": request.form.get("cluster", "true") == "true",
-                "hotspots": request.form.get("hotspots", "true") == "true",
-                "motifs": request.form.get("motifs", "true") == "true",
+                "classify": _form_flag("classify"),
+                "cluster": _form_flag("cluster"),
+                "hotspots": _form_flag("hotspots"),
+                "motifs": _form_flag("motifs"),
             },
         )
 
@@ -154,17 +303,17 @@ def register_routes(app, db, socketio):
         if not analysis:
             return jsonify({"error": "Analysis not found"}), 404
 
-        if analysis["status"] == "running":
+        # Claim the analysis atomically. Checking the status and then updating it
+        # in two statements lets two concurrent POSTs both pass the check and
+        # start duplicate threads writing the same output directory.
+        if not db.try_claim_analysis(analysis_id):
             return jsonify({"error": "Analysis already running"}), 400
 
-        # Update status
-        db.update_analysis_status(analysis_id, "running")
-
-        # Start analysis in background
-        thread = threading.Thread(
-            target=run_analysis, args=(analysis_id, db, socketio), daemon=True
+        # Run on a bounded pool: analyses are CPU and memory heavy, and an
+        # unbounded thread per request lets a burst of uploads exhaust the box.
+        app.config["ANALYSIS_EXECUTOR"].submit(
+            run_analysis, analysis_id, db, socketio, app.config["RESULTS_FOLDER"]
         )
-        thread.start()
 
         return jsonify({"status": "started", "analysis_id": analysis_id})
 
@@ -206,7 +355,7 @@ def register_routes(app, db, socketio):
         """Download a genome reference file."""
         genome_manager = app.config["GENOME_MANAGER"]
 
-        if genome not in genome_manager.SUPPORTED_GENOMES:
+        if genome not in SUPPORTED_GENOMES:
             return jsonify({"error": f"Unsupported genome: {genome}"}), 400
 
         if genome_manager.is_downloaded(genome):
@@ -239,14 +388,11 @@ def register_routes(app, db, socketio):
         if not file_record:
             return jsonify({"error": "File not found"}), 404
 
-        file_path = Path(file_record["path"]).resolve()
-        allowed_dirs = [
-            Path(app.config["UPLOAD_FOLDER"]).resolve(),
-            (Path.home() / ".mutagene" / "results").resolve(),
-        ]
-        if not any(str(file_path).startswith(str(d)) for d in allowed_dirs):
+        file_path = Path(file_record["path"])
+        if not any(_is_within(file_path, d) for d in _managed_dirs(app)):
             return jsonify({"error": "Access denied"}), 403
 
+        file_path = file_path.resolve()
         if not file_path.exists():
             return jsonify({"error": "File no longer exists on disk"}), 404
 
@@ -266,16 +412,19 @@ def register_routes(app, db, socketio):
         if analysis and analysis.get("status") == "running":
             return jsonify({"error": "Cannot delete a running analysis"}), 409
 
-        # Clean up files on disk
-        files = db.get_all_files(analysis_id)
-        for f in files:
+        # Clean up files on disk. Only unlink paths inside the directories this
+        # app owns, so a malformed or tampered DB row cannot delete elsewhere.
+        managed = _managed_dirs(app)
+        for f in db.get_all_files(analysis_id):
             file_path = Path(f["path"])
-            if file_path.exists():
-                file_path.unlink()
+            if not any(_is_within(file_path, d) for d in managed):
+                logger.warning(f"Refusing to delete file outside managed dirs: {file_path}")
+                continue
+            file_path.unlink(missing_ok=True)
 
         # Clean up result directory
-        result_dir = Path.home() / ".mutagene" / "results" / str(analysis_id)
-        if result_dir.exists():
+        result_dir = Path(app.config["RESULTS_FOLDER"]) / str(analysis_id)
+        if _is_within(result_dir, Path(app.config["RESULTS_FOLDER"])) and result_dir.exists():
             shutil.rmtree(result_dir)
 
         db.delete_analysis(analysis_id)
@@ -296,17 +445,22 @@ def register_socketio_handlers(socketio, db):
         logger.debug("Client disconnected")
 
 
-def run_analysis(analysis_id, db, socketio):
+def run_analysis(analysis_id, db, socketio, results_folder=None):
     """Run analysis in background thread.
 
     Args:
         analysis_id: Analysis ID
         db: Database manager
         socketio: SocketIO instance for progress updates
+        results_folder: Root directory for analysis output. Defaults to
+            ~/.mutagene/results
     """
     from pathlib import Path
 
     from .analysis import run_cohort_analysis
+
+    if results_folder is None:
+        results_folder = Path.home() / ".mutagene" / "results"
 
     try:
         # Get analysis details
@@ -321,7 +475,7 @@ def run_analysis(analysis_id, db, socketio):
             raise ValueError("No input file found")
 
         input_path = Path(input_files[0]["path"])
-        output_dir = Path.home() / ".mutagene" / "results" / str(analysis_id)
+        output_dir = Path(results_folder) / str(analysis_id)
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Emit progress updates
@@ -392,8 +546,37 @@ def start_server(host="127.0.0.1", port=5000, debug=False, open_browser=True):
         port: Port to bind to
         debug: Enable debug mode
         open_browser: Automatically open browser
+
+    Raises:
+        ValueError: If debug mode is requested on a non-loopback bind address.
     """
-    app, socketio = create_app()
+    is_loopback = host in ("127.0.0.1", "localhost", "::1")
+
+    if debug and not is_loopback:
+        # Werkzeug's debug mode exposes an interactive console that executes
+        # arbitrary Python for anyone who can reach it.
+        raise ValueError(
+            f"Refusing to enable debug mode while binding to {host}: the Werkzeug "
+            "debugger allows remote code execution. Use --host 127.0.0.1 with --debug."
+        )
+
+    if not is_loopback:
+        logger.warning(
+            f"Binding to {host} exposes this server on the network. It has no "
+            "authentication and runs analyses on uploaded files."
+        )
+
+    allowed_origins = [f"http://localhost:{port}", f"http://127.0.0.1:{port}"]
+    allowed_hosts = ["localhost", "127.0.0.1", "::1"]
+    if not is_loopback:
+        # The hostname clients will use is unknown for a wildcard/LAN bind, so
+        # the Host check cannot be applied; the warning above covers the risk.
+        allowed_origins.append(f"http://{host}:{port}")
+        allowed_hosts = None
+
+    app, socketio = create_app(
+        config={"ALLOWED_ORIGINS": allowed_origins, "ALLOWED_HOSTS": allowed_hosts}
+    )
 
     print(f"""
 ╔══════════════════════════════════════════════════════════════╗
@@ -427,6 +610,11 @@ def start_server(host="127.0.0.1", port=5000, debug=False, open_browser=True):
             debug=debug,
             use_reloader=False,
             log_output=not debug,  # Reduce log spam in production
+            # Flask-SocketIO refuses to start on Werkzeug unless this is set when
+            # debug is off, which made `mutagene serve` exit immediately. This is
+            # a single-user tool on loopback, which is what Werkzeug is fine for;
+            # non-loopback binds are warned about above.
+            allow_unsafe_werkzeug=True,
         )
     except KeyboardInterrupt:
         print("\n\nShutting down server...")

--- a/mutagene/webapp/templates/analyzing.html
+++ b/mutagene/webapp/templates/analyzing.html
@@ -57,15 +57,29 @@ socket.on('complete', (data) => {
     }
 });
 
+// Render a failure panel without ever parsing server-supplied text as HTML.
+function showFailure(message) {
+    const container = document.getElementById('progressContainer');
+    container.textContent = '';
+
+    const alertBox = document.createElement('div');
+    alertBox.className = 'alert alert-error';
+
+    const heading = document.createElement('h3');
+    heading.textContent = 'Analysis Failed';
+
+    const detail = document.createElement('p');
+    detail.textContent = message;
+
+    alertBox.appendChild(heading);
+    alertBox.appendChild(detail);
+    container.appendChild(alertBox);
+}
+
 socket.on('error', (data) => {
     if (data.analysis_id === analysisId) {
         document.getElementById('currentStep').textContent = '❌ Error occurred';
-        document.getElementById('progressContainer').innerHTML = `
-            <div class="alert alert-error">
-                <h3>Analysis Failed</h3>
-                <p>${data.error}</p>
-            </div>
-        `;
+        showFailure(data.error);
         addLog(`ERROR: ${data.error}`, 'error');
     }
 });
@@ -81,7 +95,11 @@ function addLog(message, type = 'info') {
     const logMessages = document.getElementById('logMessages');
     const timestamp = new Date().toLocaleTimeString();
     const color = type === 'error' ? '#dc3545' : '#667eea';
-    logMessages.innerHTML += `<div style="color: ${color}; margin-bottom: 5px;">[${timestamp}] ${message}</div>`;
+    const entry = document.createElement('div');
+    entry.style.color = color;
+    entry.style.marginBottom = '5px';
+    entry.textContent = `[${timestamp}] ${message}`;
+    logMessages.appendChild(entry);
     logMessages.parentElement.scrollTop = logMessages.parentElement.scrollHeight;
 }
 
@@ -92,12 +110,7 @@ setInterval(async () => {
     if (data.status === 'complete') {
         window.location.href = `/results/${analysisId}`;
     } else if (data.status === 'error') {
-        document.getElementById('progressContainer').innerHTML = `
-            <div class="alert alert-error">
-                <h3>Analysis Failed</h3>
-                <p>${data.error_message || 'Unknown error'}</p>
-            </div>
-        `;
+        showFailure(data.error_message || 'Unknown error');
     }
 }, 5000);
 </script>

--- a/tests/cli/cli_test_utils.py
+++ b/tests/cli/cli_test_utils.py
@@ -8,9 +8,9 @@ COHORTS_FILE = "cohorts.tar.gz"
 TEST_FILE_MAP = {
     COHORTS_FILE: "https://www.ncbi.nlm.nih.gov/research/mutagene/static/data/cohorts.tar.gz",
     "sample1.maf": "https://www.ncbi.nlm.nih.gov/research/mutagene/static/data/sample1.maf",
-    "hg19.2bit": "https://hgdownload.cse.ucsc.edu/goldenPath/hg19/bigZips/hg19.2bit",
+    "hg19.2bit": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.2bit",
 }
-# 'chrY.fa.gz': 'https://hgdownload.cse.ucsc.edu/goldenPath/hg19/chromosomes/chrY.fa.gz'
+# 'chrY.fa.gz': 'https://hgdownload.soe.ucsc.edu/goldenPath/hg19/chromosomes/chrY.fa.gz'
 
 
 # Method to run MutaGene CLI commands in a manner similar to actual CLI execution

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -24,15 +24,25 @@ def test_data():
                 shutil.copyfile(f"./{filename}", target_path)
             # Otherwise, download from public source
             else:
-                # Use stream=True to avoid automatic decompression
-                # Important for .tar.gz files that need to stay compressed
-                r = requests.get(url, stream=True)
-                r.raise_for_status()
-                r.raw.decode_content = False  # Keep content as-is, don't decode gzip
-                with open(target_path, "wb") as outfile:
-                    for chunk in r.iter_content(chunk_size=8192):
-                        if chunk:
-                            outfile.write(chunk)
+                # These fixtures pull hundreds of MB from third-party hosts
+                # (UCSC, NCBI). Their availability is outside this project's
+                # control, and an outage there should not be reported as a
+                # failure of the code under test, so skip instead of erroring.
+                try:
+                    # Use stream=True to avoid automatic decompression
+                    # Important for .tar.gz files that need to stay compressed
+                    r = requests.get(url, stream=True, timeout=60)
+                    r.raise_for_status()
+                    r.raw.decode_content = False  # Keep content as-is, don't decode gzip
+                    with open(target_path, "wb") as outfile:
+                        for chunk in r.iter_content(chunk_size=8192):
+                            if chunk:
+                                outfile.write(chunk)
+                except requests.RequestException as e:
+                    # Don't leave a truncated file behind for the next run.
+                    if os.path.isfile(target_path):
+                        os.remove(target_path)
+                    pytest.skip(f"Could not download test fixture {filename} from {url}: {e}")
 
     # Copy COHORTS_FILE to ./ for use in mutagene rank tests
     cp_cohorts = False

--- a/tests/webapp/test_analysis.py
+++ b/tests/webapp/test_analysis.py
@@ -2,12 +2,15 @@
 
 import gzip
 import tarfile
-import tempfile
-from pathlib import Path
 
 import pytest
 
-from mutagene.webapp.analysis import extract_input_file, open_input_file
+from mutagene.webapp.analysis import (
+    extract_input_file,
+    open_input_file,
+    profile_channel_order,
+    profile_dict_to_array,
+)
 
 
 class TestOpenInputFile:
@@ -73,7 +76,72 @@ class TestExtractInputFile:
 
         output_dir = tmp_path / "output"
         output_dir.mkdir()
+        escape_target = tmp_path.parent / "etc" / "mutation_passwd.maf"
         result = extract_input_file(tar_path, output_dir)
+
         # Should extract safely inside output dir, not to ../../etc/
-        assert str(output_dir) in str(result)
-        assert "etc" not in str(result)
+        assert result.resolve().is_relative_to(output_dir.resolve())
+        # The bytes must actually land at the returned path, and nowhere else.
+        assert result.exists()
+        assert result.read_text() == maf_content
+        assert not escape_target.exists()
+
+    def test_tar_gz_nested_member_is_readable(self, tmp_path):
+        # A member inside a subdirectory must be returned at a path that exists;
+        # previously the return value pointed at a basename that was never written.
+        maf_path = tmp_path / "mutations.maf"
+        maf_path.write_text("Hugo_Symbol\n")
+
+        tar_path = tmp_path / "nested.tar.gz"
+        with tarfile.open(tar_path, "w:gz") as tar:
+            tar.add(str(maf_path), arcname="data/inner/mutations.maf")
+
+        result = extract_input_file(tar_path, tmp_path / "output")
+        assert result.exists()
+        assert result.read_text() == "Hugo_Symbol\n"
+
+    def test_tar_gz_oversized_member_rejected(self, tmp_path, monkeypatch):
+        import mutagene.webapp.analysis as analysis_mod
+
+        maf_path = tmp_path / "mutations.maf"
+        maf_path.write_text("Hugo_Symbol\n" * 100)
+
+        tar_path = tmp_path / "big.tar.gz"
+        with tarfile.open(tar_path, "w:gz") as tar:
+            tar.add(str(maf_path), arcname="mutations.maf")
+
+        monkeypatch.setattr(analysis_mod, "MAX_EXTRACTED_BYTES", 10)
+        with pytest.raises(ValueError, match="too large|exceeds"):
+            extract_input_file(tar_path, tmp_path / "output")
+
+
+class TestProfileChannelOrder:
+    def test_matches_signature_matrix_row_order(self):
+        from mutagene.io.profile import get_profile_attributes_dict, read_signatures
+
+        order = profile_channel_order()
+        assert len(order) == 96
+        assert len(set(order)) == 96
+        # Must equal the order used to build W, not alphabetical order.
+        assert order == [
+            f"{a['context'][0]}[{a['mutation'][0]}>{a['mutation'][1]}]{a['context'][1]}"
+            for a in get_profile_attributes_dict()
+        ]
+        assert order != sorted(order), "alphabetical order would permute 88 of 96 channels"
+
+        W, _ = read_signatures("COSMICv3", only=None)
+        assert W.shape[0] == len(order)
+
+    def test_dict_to_array_places_counts_in_signature_order(self):
+        order = profile_channel_order()
+        # Put a marker count in a channel whose alphabetical index differs.
+        target = "A[C>A]T"
+        arr = profile_dict_to_array({target: 7})
+        assert arr.shape == (96,)
+        assert arr[order.index(target)] == 7
+        assert arr.sum() == 7
+
+    def test_dict_to_array_fills_missing_channels(self):
+        arr = profile_dict_to_array({"A[C>A]A": 3})
+        assert arr.shape == (96,)
+        assert arr.sum() == 3

--- a/tests/webapp/test_database.py
+++ b/tests/webapp/test_database.py
@@ -1,14 +1,12 @@
 """Tests for webapp database models and manager."""
 
 import json
-import tempfile
-from pathlib import Path
 
 import numpy as np
 import pytest
 
 from mutagene.webapp.database.manager import DatabaseManager
-from mutagene.webapp.database.models import Analysis, File, Result, _SafeEncoder, init_db
+from mutagene.webapp.database.models import _SafeEncoder, init_db
 
 
 @pytest.fixture
@@ -178,3 +176,48 @@ class TestFileCRUD:
 
     def test_get_nonexistent_file(self, db):
         assert db.get_file(999) is None
+
+
+class TestCascadeDelete:
+    def test_delete_removes_dependent_rows(self, db, tmp_path):
+        aid = db.create_analysis("test.maf", "hg19")
+        db.store_result(aid, "profile", {"p": 1})
+        f = tmp_path / "a.maf"
+        f.write_text("x")
+        db.register_file(aid, "input_maf", "a.maf", str(f))
+
+        assert db.get_all_results(aid) and db.get_all_files(aid)
+        db.delete_analysis(aid)
+
+        # Requires PRAGMA foreign_keys=ON; without it these rows are orphaned.
+        assert db.get_all_results(aid) == []
+        assert db.get_all_files(aid) == []
+
+
+class TestClaimAndRecovery:
+    def test_claim_is_exclusive(self, db):
+        aid = db.create_analysis("test.maf", "hg19")
+        assert db.try_claim_analysis(aid) is True
+        # Second claim must lose while the first is still running.
+        assert db.try_claim_analysis(aid) is False
+        assert db.get_analysis(aid)["status"] == "running"
+
+    def test_claim_unknown_analysis(self, db):
+        assert db.try_claim_analysis(999) is False
+
+    def test_claim_clears_previous_error(self, db):
+        aid = db.create_analysis("test.maf", "hg19")
+        db.update_analysis_status(aid, "error", "boom")
+        assert db.try_claim_analysis(aid) is True
+        assert db.get_analysis(aid)["error_message"] is None
+
+    def test_reset_stale_running(self, db):
+        running = db.create_analysis("a.maf", "hg19")
+        done = db.create_analysis("b.maf", "hg19")
+        db.update_analysis_status(running, "running")
+        db.update_analysis_status(done, "complete")
+
+        assert db.reset_stale_running() == 1
+        assert db.get_analysis(running)["status"] == "error"
+        assert "interrupted" in db.get_analysis(running)["error_message"]
+        assert db.get_analysis(done)["status"] == "complete"

--- a/tests/webapp/test_genome_manager.py
+++ b/tests/webapp/test_genome_manager.py
@@ -1,0 +1,80 @@
+"""Tests for webapp genome reference management."""
+
+import pytest
+
+from mutagene.webapp.genome_manager import GenomeManager
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return GenomeManager(genomes_dir=tmp_path / "genomes")
+
+
+class TestGenomePathValidation:
+    def test_supported_genome_resolves_inside_dir(self, manager):
+        path = manager.get_genome_path("hg19")
+        assert path.parent == manager.genomes_dir
+        assert path.name == "hg19.2bit"
+
+    @pytest.mark.parametrize(
+        "genome",
+        ["../../etc/passwd", "/etc/passwd", "hg19/../../secret", "", "HG19"],
+    )
+    def test_rejects_unsupported_names(self, manager, genome):
+        # An unchecked name here becomes part of a filesystem path.
+        with pytest.raises(ValueError):
+            manager.get_genome_path(genome)
+
+    def test_is_downloaded_is_false_for_unknown_name(self, manager):
+        assert manager.is_downloaded("../../etc/passwd") is False
+
+
+class TestAtomicDownload:
+    def test_failed_download_leaves_no_usable_file(self, manager, monkeypatch):
+        def boom(url, dst):
+            # Simulate a download that dies partway through.
+            with open(dst, "wb") as fh:
+                fh.write(b"partial")
+            raise OSError("connection reset")
+
+        monkeypatch.setattr("mutagene.webapp.genome_manager.download_from_url", boom)
+
+        assert manager.download_genome("hg19") is False
+        assert not manager.is_downloaded("hg19")
+        assert not manager.get_genome_path("hg19").exists()
+        assert list(manager.genomes_dir.iterdir()) == []
+
+    def test_successful_download_is_promoted(self, manager, monkeypatch):
+        def ok(url, dst):
+            with open(dst, "wb") as fh:
+                fh.write(b"2bit-data")
+
+        monkeypatch.setattr("mutagene.webapp.genome_manager.download_from_url", ok)
+
+        assert manager.download_genome("hg19") is True
+        assert manager.is_downloaded("hg19")
+        assert manager.get_genome_path("hg19").read_bytes() == b"2bit-data"
+
+    def test_download_writes_to_temp_path_first(self, manager, monkeypatch):
+        seen = {}
+
+        def capture(url, dst):
+            seen["dst"] = dst
+            with open(dst, "wb") as fh:
+                fh.write(b"x")
+
+        monkeypatch.setattr("mutagene.webapp.genome_manager.download_from_url", capture)
+        manager.download_genome("hg38")
+
+        assert seen["dst"].endswith(".part")
+        assert seen["dst"] != str(manager.get_genome_path("hg38"))
+
+    def test_unsupported_genome_is_not_downloaded(self, manager):
+        assert manager.download_genome("nonexistent") is False
+
+
+class TestGenomeInfo:
+    def test_reports_all_supported_genomes(self, manager):
+        info = manager.get_genome_info()
+        assert set(info) == set(GenomeManager.SUPPORTED_GENOMES)
+        assert all(entry["downloaded"] is False for entry in info.values())

--- a/tests/webapp/test_server.py
+++ b/tests/webapp/test_server.py
@@ -1,8 +1,5 @@
 """Tests for webapp Flask server routes."""
 
-import json
-import tempfile
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -153,3 +150,143 @@ class TestResultsPage:
         response = client.get(f"/results/{aid}")
         assert response.status_code == 200
         assert b"progress" in response.data.lower()
+
+
+class TestUploadValidation:
+    def _upload(self, client, filename="test.maf", **form):
+        from io import BytesIO
+
+        data = {"file": (BytesIO(b"Hugo_Symbol\tChromosome\n"), filename)}
+        data.update(form)
+        return client.post("/api/upload", data=data, content_type="multipart/form-data")
+
+    def test_rejects_unknown_genome(self, client):
+        # An unvalidated value here reaches GenomeManager.get_genome_path()
+        # and is interpolated into a filesystem path.
+        response = self._upload(client, genome="../../../../etc/passwd")
+        assert response.status_code == 400
+        assert "genome" in response.get_json()["error"].lower()
+
+    def test_rejects_unknown_signature_set(self, client):
+        response = self._upload(client, genome="hg19", signatures="EVIL")
+        assert response.status_code == 400
+
+    def test_rejects_unsupported_extension(self, client):
+        response = self._upload(client, filename="payload.exe", genome="hg19")
+        assert response.status_code == 400
+
+    def test_rejects_filename_that_sanitizes_to_nothing(self, client):
+        response = self._upload(client, filename="..", genome="hg19")
+        assert response.status_code == 400
+
+    def test_truncates_long_name(self, client, db):
+        from mutagene.webapp.server import MAX_NAME_LENGTH
+
+        response = self._upload(client, genome="hg19", name="A" * 5000)
+        assert response.status_code == 200
+        aid = response.get_json()["analysis_id"]
+        assert len(db.get_analysis(aid)["name"]) == MAX_NAME_LENGTH
+
+    def test_checkbox_on_enables_option(self, client, db):
+        # Browsers submit "on" for a checked box with no value attribute.
+        response = self._upload(client, genome="hg19", classify="on")
+        aid = response.get_json()["analysis_id"]
+        config = db.get_analysis(aid)["config"]
+        assert config["classify"] is True
+
+    def test_omitted_checkbox_disables_option(self, client, db):
+        response = self._upload(client, genome="hg19")
+        aid = response.get_json()["analysis_id"]
+        config = db.get_analysis(aid)["config"]
+        assert config["classify"] is False
+        assert config["cluster"] is False
+
+
+class TestRequestGuards:
+    def test_rejects_foreign_host_header(self, client):
+        response = client.get("/", headers={"Host": "evil.example.com"})
+        assert response.status_code == 400
+
+    def test_allows_loopback_host(self, client):
+        assert client.get("/", headers={"Host": "127.0.0.1:5000"}).status_code == 200
+
+    def test_blocks_cross_origin_state_change(self, client, db):
+        aid = db.create_analysis("test.maf", "hg19")
+        response = client.delete(
+            f"/api/delete/{aid}", headers={"Origin": "http://evil.example.com"}
+        )
+        assert response.status_code == 403
+        assert db.get_analysis(aid) is not None
+
+    def test_allows_same_origin_state_change(self, client, db):
+        aid = db.create_analysis("test.maf", "hg19")
+        response = client.delete(f"/api/delete/{aid}", headers={"Origin": "http://localhost:5000"})
+        assert response.status_code == 200
+
+    def test_get_is_not_origin_checked(self, client):
+        response = client.get("/", headers={"Origin": "http://evil.example.com"})
+        assert response.status_code == 200
+
+
+class TestDeleteSafety:
+    def test_refuses_to_unlink_outside_managed_dirs(self, client, db, tmp_path):
+        aid = db.create_analysis("test.maf", "hg19")
+        outside = tmp_path / "outside" / "important.txt"
+        outside.parent.mkdir(parents=True)
+        outside.write_text("keep me")
+        db.register_file(aid, "output", "important.txt", str(outside))
+
+        assert client.delete(f"/api/delete/{aid}").status_code == 200
+        assert outside.exists(), "file outside upload/results dirs must not be deleted"
+
+    def test_deletes_managed_file(self, client, db, app):
+        aid = db.create_analysis("test.maf", "hg19")
+        managed = app.config["UPLOAD_FOLDER"] / "input.maf"
+        managed.write_text("data")
+        db.register_file(aid, "input_maf", "input.maf", str(managed))
+
+        assert client.delete(f"/api/delete/{aid}").status_code == 200
+        assert not managed.exists()
+
+    def test_refuses_to_delete_running_analysis(self, client, db):
+        aid = db.create_analysis("test.maf", "hg19")
+        db.update_analysis_status(aid, "running")
+        assert client.delete(f"/api/delete/{aid}").status_code == 409
+
+
+class TestAnalyzeConcurrency:
+    def test_second_start_is_rejected(self, client, db, app):
+        from unittest.mock import MagicMock
+
+        app.config["ANALYSIS_EXECUTOR"] = MagicMock()
+        aid = db.create_analysis("test.maf", "hg19")
+
+        assert client.post(f"/api/analyze/{aid}").status_code == 200
+        assert client.post(f"/api/analyze/{aid}").status_code == 400
+        # Only one worker may ever be submitted for a single claim.
+        assert app.config["ANALYSIS_EXECUTOR"].submit.call_count == 1
+
+
+class TestStartServerGuards:
+    def test_debug_on_public_host_is_refused(self):
+        from mutagene.webapp.server import start_server
+
+        # The Werkzeug debugger is an RCE console; it must never be network-reachable.
+        with pytest.raises(ValueError, match="debug mode"):
+            start_server(host="0.0.0.0", port=5000, debug=True, open_browser=False)
+
+    def test_debug_on_loopback_is_allowed_through_guard(self, monkeypatch):
+        import mutagene.webapp.server as server_mod
+
+        called = {}
+
+        def fake_create_app(config=None):
+            called["config"] = config
+            raise RuntimeError("stop before binding")
+
+        monkeypatch.setattr(server_mod, "create_app", fake_create_app)
+        with pytest.raises(RuntimeError, match="stop before binding"):
+            server_mod.start_server(host="127.0.0.1", port=8080, debug=True, open_browser=False)
+
+        # Origins must track the actual port, not a hardcoded 5000.
+        assert "http://127.0.0.1:8080" in called["config"]["ALLOWED_ORIGINS"]


### PR DESCRIPTION

**Correctness**
- Signature decomposition used alphabetical key order instead of signature-matrix row order, permuting 88 of 96 channels. Lung sample now reports SBS4 (smoking) instead of SBS27 (artifact).
- Checkboxes submit `on`, server compared to `"true"` — checked boxes disabled their analysis.
- `mutagene serve` exited on startup; needs `allow_unsafe_werkzeug=True`.
- UCSC hostname `hgdownload.cse.ucsc.edu` has an invalid cert; switched to `.soe.`.
- CLI tests now skip instead of failing when third-party fixture downloads are unavailable.

**Security**
- Tar extraction validated one path but extracted another, allowing writes outside the target dir.
- Error text reached `innerHTML`; now `textContent`.
- `genome`/signature values validated before hitting the filesystem; uploads check extension and name length.
- Path containment uses `is_relative_to`, not string prefixing; deletion applies the same check.
- Origin/Host guards added; `--debug` refused on non-loopback binds.

**Robustness**
- `PRAGMA foreign_keys` enabled so `ON DELETE CASCADE` fires.
- Atomic analysis claim, bounded worker pool, stale runs reset on restart.
- Genome downloads serialized per assembly, promoted from `.part`, moved off startup path.
- Mismatch counter ignores other threads; clustering capped by sample count.